### PR TITLE
[Language Configuration] Fix commenting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": "BTW",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "blockComment": [ "OBTW", "TLDR" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
Changed line and block comments to `BTW` and `OBTW, TLDR`

Here's an example using the comment keybinds
![](https://chr1s.dev/sharex/files/j2z1lxe.gif)